### PR TITLE
Allow to show subtitles

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -68,7 +68,7 @@ const onPlayerReady = (player, options) => {
 					const track = tracks[i];
 
 					// Find the right captions track and mark it as "showing".
-					if (track.kind === 'captions' && track.language === val) {
+          if ((track.kind === 'captions' || track.kind === 'subtitles') && track.language === val) {
 						track.mode = 'showing';
 					}
 				}


### PR DESCRIPTION
Hi this change allows us to find and mark the textTrack from those with kind subtitles.

For the case, I´m doing this because in some cases the textTracks are embedded in the asset which means you are not allowed to just change the kind on the HTML tag.

https://docs.mux.com/guides/video/add-subtitles-to-your-videos